### PR TITLE
[WIP] Fix some problems

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,17 +12,17 @@ module.exports.createURI = function (protocol,base,port,path) {
     throw "prtocol and base must be specified"
   }
 
-  format = ["%s://","%s",":%d","%s"]
-  sformat = ""
-  farguments = []
-  for (i = 0; i < arguments.length; i++) {
+  const format = ["%s://","%s",":%d","%s"]
+  let sformat = ""
+  const farguments = []
+  for (let i = 0; i < arguments.length; i++) {
         if (arguments[i] !== undefined) {
           sformat += format[i]
           farguments.push(arguments[i])
         }
   }
 
-  url = util.format(sformat,...farguments)
+  const url = util.format(sformat,...farguments)
   //check valid uri
   new Url(url)
   return url


### PR DESCRIPTION
Hi @relu91 .
I'm trying to use NPM @arces-wot/sepa-js package inside my Angular 9 app.
First problem is that some **_let_** and **_const_** were missing in function `createURI` (see `util.js: 6`),
and so Angular was unable to compile this dependency.
~~The other problem is that the Node.js `https` module is not available inside the browser context (as far as I was able to understand), leading to these error messages:~~

> ~~ERROR in ./node_modules/@arces-wot/sepa-js/lib/defaults.js
> Module not found: Error: Can't resolve 'https' in 'D:\iosonopersia\Documents\GitHub\ng-covid19\node_modules\@arces-wot\sepa-js\lib'~~

> ~~ERROR in ./node_modules/@arces-wot/sepa-js/lib/secure.js
> Module not found: Error: Can't resolve 'https' in 'D:\iosonopersia\Documents\GitHub\ng-covid19\node_modules\@arces-wot\sepa-js\lib'~~

~~I attached my temporary solution (commenting out every https reference), but obviously that may not be the right thing to do, since this way it may be impossible to use a secure connection. I don't know how to do better, maybe there are other `https` in-browser alternatives.~~